### PR TITLE
repeaterContainer and scrolledBottom

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -105,7 +105,8 @@
 						'vsRepeat': 'elementSize',
 						'vsOffsetBefore': 'offsetBefore',
 						'vsOffsetAfter': 'offsetAfter',
-						'vsExcess': 'excess'
+                        'vsScrolledBottomOffset': 'scrolledBottomOffset',
+                        'vsExcess': 'excess'
 					};
 
 				repeatContainer.empty();
@@ -130,7 +131,9 @@
 
 							clientSize =  $$horizontal ? 'clientWidth' : 'clientHeight',
 							offsetSize =  $$horizontal ? 'offsetWidth' : 'offsetHeight',
-							scrollPos =  $$horizontal ? 'scrollLeft' : 'scrollTop';
+							scrollPos =  $$horizontal ? 'scrollLeft' : 'scrollTop',
+
+                            scrolledBottomEnabled = angular.isDefined($attrs.vsScrolledBottom);
 
 						if($scrollParent.length === 0) throw 'Specified scroll parent selector did not match any element';
 						$scope.$scrollParent = $scrollParent;
@@ -618,6 +621,13 @@
 
 								// Emit the event
 								$scope.$emit('vsRepeatInnerCollectionUpdated', $scope.startIndex, $scope.endIndex, _prevStartIndex, _prevEndIndex);
+							}
+
+							if (scrolledBottomEnabled) {
+								var triggerIndex = originalCollection.length - ($scope.scrolledBottomOffset || 0);
+								if($scope.endIndex >= triggerIndex && _prevEndIndex < triggerIndex) {
+									$scope.$evalAsync($attrs.vsScrolledBottom);
+								}
 							}
 
 							_prevStartIndex = $scope.startIndex;

--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -92,7 +92,8 @@
 				this.$fillElement = $scope.$fillElement;
 			}],
 			compile: function($element, $attrs){
-				var ngRepeatChild = $element.children().eq(0),
+				var repeatContainer = angular.isDefined($attrs.vsRepeatContainer) ? angular.element($element[0].querySelector($attrs.vsRepeatContainer)) : $element,
+					ngRepeatChild = repeatContainer.children().eq(0),
 					ngRepeatExpression = ngRepeatChild.attr('ng-repeat'),
 					childCloneHtml = ngRepeatChild[0].outerHTML,
 					expressionMatches = /^\s*(\S+)\s+in\s+([\S\s]+?)(track\s+by\s+\S+)?$/.exec(ngRepeatExpression),
@@ -107,9 +108,9 @@
 						'vsExcess': 'excess'
 					};
 
-				$element.empty();
-				if(!window.getComputedStyle || window.getComputedStyle($element[0]).position !== 'absolute')
-					$element.css('position', 'relative');
+				repeatContainer.empty();
+				if(!window.getComputedStyle || window.getComputedStyle(repeatContainer[0]).position !== 'absolute')
+					repeatContainer.css('position', 'relative');
 				return {
 					pre: function($scope, $element, $attrs, $ctrl){
 						var childClone = angular.element(childCloneHtml),
@@ -120,7 +121,8 @@
 							$fillElement,
 							autoSize = !$attrs.vsRepeat,
 							sizesPropertyExists = !!$attrs.vsSizeProperty,
-							$scrollParent = $attrs.vsScrollParent ? closestElement.call($element, $attrs.vsScrollParent) : $element,
+
+							$scrollParent = $attrs.vsScrollParent ? closestElement.call(repeatContainer, $attrs.vsScrollParent) : repeatContainer,
 							positioningPropertyTransform = $$horizontal ? 'translateX' : 'translateY',
 							positioningProperty = $$horizontal ? 'left' : 'top',
 
@@ -145,7 +147,7 @@
 							scrollIndexPosition: 'top',
 						};
 
-						$scope.$watch($attrs.vsScrollSettings, function(newValue, oldValue) {
+                        $scope.$watch($attrs.vsScrollSettings, function(newValue, oldValue) {
 							if (typeof newValue === 'undefined') {
 								return;
 							}
@@ -200,8 +202,8 @@
 						function setAutoSize(){
 							if(autoSize){
 								$scope.$$postDigest(function(){
-									if($element[0].offsetHeight || $element[0].offsetWidth){ // element is visible
-										var children = $element.children(),
+									if(repeatContainer[0].offsetHeight || repeatContainer[0].offsetWidth){ // element is visible
+										var children = repeatContainer.children(),
 											i = 0;
 										while(i < children.length){
 											if(children[i].attributes['ng-repeat'] != null){
@@ -219,7 +221,7 @@
 									}
 									else{
 										var dereg = $scope.$watch(function(){
-											if($element[0].offsetHeight || $element[0].offsetWidth){
+											if(repeatContainer[0].offsetHeight || repeatContainer[0].offsetWidth){
 												dereg();
 												setAutoSize();
 											}
@@ -247,7 +249,7 @@
 						}
 
 						$compile(childClone)($scope);
-						$element.append(childClone);
+						repeatContainer.append(childClone);
 
 						$fillElement = angular.element('<div class="vs-repeat-fill-element"></div>')
 							.css({
@@ -255,7 +257,7 @@
 								'min-height': '100%',
 								'min-width': '100%'
 							});
-						$element.append($fillElement);
+						repeatContainer.append($fillElement);
 						$compile($fillElement)($scope);
 						$scope.$fillElement = $fillElement;
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -347,5 +347,39 @@
 
             done();
         });
+
+        it ('should execute function when scrolled to offset', function (done) {
+            $element = angular.element([
+                '	<div vs-repeat="20" vs-scrolled-bottom="updateCounter()" vs-scrolled-bottom-offset="20" class="container">',
+                '       <div ng-repeat="foo in bar" class="item">',
+                '		    <span class="value">{{foo.value}}</span>',
+                '		</div>',
+                '	</div>'
+            ].join(''));
+
+            angular.element(document.body).append($element);
+            $compile($element)($scope);
+            $scope.bar = getArray(100);
+            $scope.$digest();
+
+            var counter = 0;
+            $scope.updateCounter = function(){
+                counter += 1;
+            };
+
+            $element[0].scrollTop = $element[0].scrollHeight * 0.6;
+            $element.triggerHandler('scroll');
+            $scope.$digest();
+
+            expect(counter).to.be(0);
+
+            $element[0].scrollTop = $element[0].scrollHeight * 0.8;
+            $element.triggerHandler('scroll');
+            $scope.$digest();
+
+            expect(counter).to.be(1);
+
+            done();
+        });
 	});
 })();

--- a/test/spec.js
+++ b/test/spec.js
@@ -321,5 +321,31 @@
 
 			done();
 		});
+        
+        it ('should support ngRepeater container selector', function (done) {
+            $element = angular.element([
+            '	<div vs-repeat vs-repeat-container=".container">',
+            '	    <div class="container" >',
+            '		    <div ng-repeat="foo in bar" class="item">',
+            '			    <span class="value">{{foo.value}}</span>',
+            '		    </div>',
+            '	    </div>',
+            '	</div>'
+            ].join(''));
+
+            angular.element(document.body).append($element);
+            $compile($element)($scope);
+            $scope.bar = getArray(100);
+            $scope.$digest();
+
+            var elems, count;
+
+            elems = getElements($element);
+            count = elems.length;
+            expect(count).to.be.greaterThan(0);
+            expect(count).to.be.lessThan(20);
+
+            done();
+        });
 	});
 })();


### PR DESCRIPTION
Allowing repeated element to not be child of vs-repeat directive.

Executing a function when scrolled to the bottom of the list, in my case I use it to load more data.