### PR TITLE
Perform vsSetOffset-refresh in next $digest ( fixes #57 )

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -405,7 +405,11 @@
                                                 $scope.sizesCumulative[originalLength] :
                                                 $scope.elementSize * originalLength
                                             );
-                            $scope.$broadcast('vsSetOffset-refresh');
+
+                            // Allow Angular to update ng-repeat $index values before syncing offsets:
+                            $scope.$evalAsync(function(){
+                                $scope.$broadcast('vsSetOffset-refresh');
+                            });
                             $scope.$emit('vsRepeatReinitialized', $scope.startIndex, $scope.endIndex);
                         }
 


### PR DESCRIPTION
To allow Angular to update repeated elements first. This fixed bug #57