### PR TITLE
honoring original scrollSettings when rebuilding underlying collectio…

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -217,7 +217,7 @@
 
                         $scope.$watchCollection(rhs, function(coll) {
                             originalCollection = coll || [];
-                            refresh();
+                            refresh($scope.scrollSettings);
                         });
 
                         function refresh(event, data) {
@@ -466,7 +466,7 @@
                         function reinitOnClientHeightChange() {
                             var ch = getClientSize($scrollParent[0], clientSize);
                             if (ch !== _prevClientSize) {
-                                reinitialize();
+                                reinitialize($scope.scrollSettings);
                                 if ($scope.$root && !$scope.$root.$$phase) {
                                     $scope.$apply();
                                     $scope.$broadcast('vsSetOffset-refresh');


### PR DESCRIPTION
…n so that we don't scroll to the top and then re-scroll to the correct location.  We just sit right where we need to be based on the scroll settings.