### PR TITLE
Scrollbar still remains when removing all the items from the array

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -263,9 +263,7 @@
                             if (!originalCollection || originalCollection.length < 1) {
                                 $scope[collectionName] = [];
                                 originalLength = 0;
-                                updateTotalSize(0);
                                 $scope.sizesCumulative = [0];
-                                return;
                             }
                             else {
                                 originalLength = originalCollection.length;


### PR DESCRIPTION
Reinitialize indexes and update inner collection in order to resize layout
Fix #103 