### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,19 +83,19 @@ bugfixes
 Version 1.0.0-rc6 (2014/09/29)
 =================
 
-###FEATURES
+### FEATURES
   * added support for resizing items by changing the item size property and then `$broadcasting()`ing the ``vsRepeatTrigger`` event.
 
 Version 1.0.0-rc5 (2014/08/01)
 =================
 
-###FEATURES
+### FEATURES
   * added an optional `vs-autoresize` attribute. You can use it without `vs-size-property` and without specifying element's size. The automatically computed element style will readjust upon window resize if the size is dependable on the viewport size.
 
 Version 1.0.0-rc4 (2014/07/15)
 =================
 
-###FEATURES
+### FEATURES
   * added support for filters in the `ngRepeat` expression
   * added support for variable items sizes (if they are known up front)
 
@@ -110,7 +110,7 @@ Semver compatible version name
 Version 1.0.0rc1 (2014/06/02)
 =================
 
-###FEATURES
+### FEATURES
 - added travis-ci integration
 - added unit tests
 - added minified version of the library
@@ -120,26 +120,26 @@ Version 1.0.0rc1 (2014/06/02)
 Version 0.3 (2014/05/30)
 =================
 
-###FEATURES
+### FEATURES
 - support for automatic computation of repeated elements' `height`/`width`
 
-###BREAKING CHANGE:
+### BREAKING CHANGE:
 - specifying the single element's size as a value of the `vs-repeat` attribute is no longer required. If it isn't provided the directive will calculate it automatically (once, the first time it renders at least one element). If for some reason you want to override that size, you can still provide is as a value of the `vs-repeat` attribute.
 
 Version 0.2 (2014/05/25)
 =================
 
-###FEATURES
+### FEATURES
 - support for horizontally stacked elements (a `vs-horizontal` attribute must be placed on the element)
 - no need to use jQuery, `vsRepeat` can now work with angular (jqLite) only
 - support for before/after offsets (in pixels) via `vs-offset-before` and `vs-offset-after`
 - full support for nested `vsRepeat`s and scrolling in both directions even within the same container
 
-###BREAKING CHANGE:
+### BREAKING CHANGE:
 - `vs-top-offset` attribute is now called `vs-offset-before`
 
 Version 0.1
 =================
 
-###FEATURES
+### FEATURES
 - support for vertically stacked elements

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ You can find the source code for this demo on branch "gh-pages".
 
 Changelog: https://github.com/kamilkp/angular-vs-repeat/blob/master/CHANGELOG.md
 
-###DESCRIPTION:
+### DESCRIPTION:
 `vsRepeat` directive stands for **Virtual Scroll Repeat**. It turns a standard ngRepeated set of elements in a scrollable container
 into a component, where the user thinks he has all the elements rendered and all he needs to do is scroll (without any kind of
 pagination - which most users loath) and at the same time the browser isn't overloaded by that many elements/angular bindings etc.
 The directive renders only so many elements that can fit into current container's `clientHeight`/`clientWidth`.
 
-###LIMITATIONS:
+### LIMITATIONS:
 - current version only supports an Array as a right-hand-side object for `ngRepeat`
 - all rendered elements must have the same height/width or the sizes of the elements must be known up front
 
-###USAGE:
+### USAGE:
 First include `vs-repeat` as a module dependency in your app.
 In order to use the vsRepeat directive you need to place a vs-repeat attribute on a direct parent of an element with ng-repeat
 example:
@@ -78,7 +78,7 @@ example:
 - the library also supports ng-repeat-start/ng-repeat-end syntax
 - the value of vsRepeat attribute is the single element's height/width measured in pixels. If none provided, the directive will compute it automatically
 
-###OPTIONAL PARAMETERS (attributes):
+### OPTIONAL PARAMETERS (attributes):
 - `vs-scroll-parent="selector"` - selector to the scrollable container. The directive will look for a closest parent matching the given selector (defaults to the current element). It can also have the value of "window" in which case the directive will hook on the main window scrollbar
 - `vs-offset-before="value"` - top/left offset in pixels (defaults to 0)
 - `vs-offset-after="value"` - bottom/right offset in pixels (defaults to 0)
@@ -90,7 +90,7 @@ example:
 - `vs-scrolled-to-end="callback"` callback will be called when the last item of the list is rendered
 - `vs-scrolled-to-end-offset="integer"` - set this number to trigger the scrolledToEnd callback n items before the last gets rendered
 
-###EVENTS:
+### EVENTS:
 - `vsRepeatTrigger` - an event the directive listens for to manually trigger reinitialization
 - `vsRepeatResize` - an event the directive listens for to manually trigger the autosizing algorithm
 - `vsRepeatReinitialized` - an event the directive emits upon reinitialization done; the listener may accepts three arguments: `event`, `startIndex` and `endIndex`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
