### PR TITLE
Adding license info to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.7",
   "description": "Virtual Scroll for AngularJS ngRepeat directive",
   "homepage": "http://kamilkp.github.io/angular-vs-repeat",
+  "license": "MIT",
   "author": {
     "name": "Kamil Pekala",
     "email": "kamilkp@gmail.com",


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.