### PR TITLE
floor/ceil of start/end index

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -528,6 +528,9 @@
                                 );
                             }
 
+                            __startIndex = Math.floor(__startIndex);
+                            __endIndex = Math.ceil(__endIndex);
+                            
                             _minStartIndex = Math.min(__startIndex, _minStartIndex);
                             _maxEndIndex = Math.max(__endIndex, _maxEndIndex);
 


### PR DESCRIPTION
without this mod there is a problem when $scope.excess is an odd value: __startIndex and __endIndex are decimal values.