### PR TITLE
Add Angular as a Bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,9 @@
   "description": "Virtual Scroll for AngularJS ngRepeat directive",
   "homepage": "http://kamilkp.github.io/angular-vs-repeat",
   "main": "dist/angular-vs-repeat.min.js",
+  "dependencies": {
+    "angular": ">= 1.2.0"
+  },
   "keywords": [
     "angularjs",
     "javascript",


### PR DESCRIPTION
## Problem
If you are using a tool to bundle such as https://github.com/ck86/main-bower-files for bundling packages, `angular-vs-repeat` will be bundled before `angular`. This obviously causes errors, and the directive is unusable.

## Solution
Setting angular as a dependency resolves the issue. 

I have set the dependency as `"angular": ">= 1.2.0"` since `1.2.16` is used for developing/testing the directive: https://github.com/kamilkp/angular-vs-repeat/blob/master/lib/angular.js