### PR TITLE
Allow any expression after 'track by '

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -214,7 +214,7 @@
 
         const [originalNgRepeatAttr, ngRepeatExpression, isNgRepeatStart] = analyzeNgRepeatUsage(ngRepeatChild);
 
-        const expressionMatches = /^\s*(\S+)\s+in\s+([\S\s]+?)(track\s+by\s+\S+)?$/.exec(ngRepeatExpression);
+        const expressionMatches = /^\s*(\S+)\s+in\s+([\S\s]+?)(track\s+by\s+\.+)?$/.exec(ngRepeatExpression);
         const [, lhs, rhs, rhsSuffix] = expressionMatches;
 
         if (isNgRepeatStart) {


### PR DESCRIPTION
Hi @kamilkp 

I am using your library in one of my projects, I have found that is not possible to ' track by SOME_EXPRESSION' that can be possible normally using ng-repeat. 

I hope this change can help you or any other with the same use case...

BTW you could find more information about what I was trying to achieve and you could do with this change ;)
https://www.bennadel.com/blog/2920-using-a-compound-track-by-expression-with-ngrepeat-in-angularjs.htm