### PR TITLE
Make copyright notice webpack compliant.

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -1,6 +1,14 @@
-/**
- * Copyright Kamil Pękala http://github.com/kamilkp
- * Angular Virtual Scroll Repeat v2.0.9 2018/04/02
+/*!
+ * Angular Virtual Scroll Repeat v2.0.9
+ * https://github.com/kamilkp/angular-vs-repeat/
+ *
+ * Copyright Kamil Pękala
+ * http://github.com/kamilkp
+ *
+ * Released under the MIT License
+ * https://opensource.org/licenses/MIT
+ *
+ * Date: 2018/04/02
  */
 
 /* global console, setTimeout, module */


### PR DESCRIPTION
Currently the copyright header will be stripped by Webpack, and doesn't include a license notice, which means that angular-vs-repeat can't be correctly redistributed under the MIT license. 

By default however, comments with `@license`, `@preserve` or starting with `/*!` are preserved by Webpack, so I've updated the header accordingly.

https://github.com/webpack/webpack/issues/324#issuecomment-157855568